### PR TITLE
Support angular expression in name and don't use global mouse events

### DIFF
--- a/angular-carousel.js
+++ b/angular-carousel.js
@@ -220,8 +220,13 @@ angular.module('angular-carousel', [])
                 if(slides.length > 0) {
 
                     // Create new carousel and duplicate slides
-                    name = attrs.ngCarouselName;
-                    currentCarousel = Carousel.add(slides.length, attrs.ngCarouselName, scope, {
+                    if(attrs.ngCarouselName != undefined){
+                        name = attrs.ngCarouselName;
+                    }
+                    else if(attrs.ngCarouselExpression != undefined) {
+                        name = scope.$eval(attrs.ngCarouselExpression);
+                    }
+                    currentCarousel = Carousel.add(slides.length, name, scope, {
                         looping: looping
                     });
                     angular.forEach(savedCallbacks, function(savedCallback) {

--- a/angular-carousel.js
+++ b/angular-carousel.js
@@ -402,8 +402,8 @@ angular.module('angular-carousel', [])
             scope.$on('$destroy', function() {
                 $timeout.cancel(refreshInteractionWithDomTimer);
                 element.off('mouseover mouseout');
-                $document.off(pressEvent);
-                $document.off(releaseEvent);
+                $document.off(pressEvent, carouselPress);
+                $document.off(releaseEvent, carouselRelease);
                 slideContainer.off('transitionend oTransitionEnd webkitTransitionEnd');
                 currentCarousel.onSlideChangeCallbacks = [];
                 Carousel.remove(name);


### PR DESCRIPTION
We have added an additional attribute ngCarouselExpression where you can give a real angular expression for the name.

Also we have change registration and unregistration of mouse events such that it does not affect other ui elements any more (because that was what is did),
